### PR TITLE
feat: use process.emitWarning instead of console.warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Logs a message on postinstall if the Node.js version being used is not supported
 
 ## Output
 
-The following message will be logged on postinstall on unsupported Node.js versions:
+The following message will be logged on postinstall on unsupported Node.js version vX.Y.Z:
 
 ```console
-The Node.js version vX.Y.Z is no longer supported.
+(node:<LINE_NUMEBR>) NodeDeprecationWarning: The Node.js version vX.Y.Z is no longer supported.
 ```

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "devDependencies": {
     "@types/node": "14",
     "typescript": "4.3.5"
+  },
+  "engines": {
+    "node": ">=6.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,8 @@
 const version = process.version;
 
 if (version && parseInt(version.substring(1, version.indexOf("."))) < 10) {
-  console.warn(`The Node.js version ${version} is no longer supported.`);
+  process.emitWarning(
+    `The Node.js version ${version} is no longer supported.`,
+    `NodeDeprecationWarning`
+  );
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Uses `process.emitWarning` instead of `console.warn` to display deprecation message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
